### PR TITLE
[1.20.1] Fixed Issue #6 - RightClicking Chickens deleted them completly

### DIFF
--- a/src/main/java/geni/witherutils/base/common/event/WitherCraftingEvents.java
+++ b/src/main/java/geni/witherutils/base/common/event/WitherCraftingEvents.java
@@ -40,7 +40,7 @@ public class WitherCraftingEvents {
 				
 				Chicken chicken = (Chicken) entity;
 				chicken.blockPosition();
-				chicken.remove(RemovalReason.KILLED);
+				// chicken.remove(RemovalReason.KILLED);
 				ChickenNaked chickennaked = WUTEntities.CHICKENNAKED.get().create(world);
 				chickennaked.moveTo(chicken.getX(), chicken.getY(), chicken.getZ(), chicken.xRotO, chicken.yRotO);
 				chickennaked.setHealth(chicken.getHealth());
@@ -54,6 +54,7 @@ public class WitherCraftingEvents {
 						CompoundTag nbt = entity.getPersistentData();
 						if (!nbt.contains("nakedChickey"))
 						{
+							chicken.remove(RemovalReason.KILLED);
 							entity.setInvulnerable(true);
 							nbt.putBoolean("nakedChickey", true);
 							world.addFreshEntity((Entity) chickennaked);


### PR DESCRIPTION
Right clicking any chicken without shears it will cause that remove it ignoring item holding

[issue related](https://legacy.curseforge.com/minecraft/mc-mods/witherutils/issues/6)